### PR TITLE
expand Travis CI test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,61 @@
 language: clojure
-lein: lein2
-script: "lein2 all do clean, test"
+lein: 2.8.1
+sudo: false
+cache:
+  directories:
+    - $HOME/.m2
+script: make $TARGET
+env:
+  matrix:
+    - VERSION=1.9 TARGET=test
+  #global:
+  #  - secure: "abc" # placeholder for deployment credentials
+  #  - secure: "xyz"
 jdk:
-  - openjdk7
-  - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
+stages:
+  - name: check
+  - name: test
+  # Deploy only from the home repo where the credentials can be
+  # properly decrypted. Never deploy from a pull request job.
+  # In addition, ensure we're on the master branch (snapshots)
+  # or a branch with semver naming (releases).
+  #- name: deploy
+  #  if: repo = clojure-emacs/orchard
+  #      AND type != pull_request
+  #      AND ( branch = master OR branch =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ )
+jobs:
+  include:
+    # Test latest OpenJDK against latest Clojure stable
+    - env: VERSION=1.9 TARGET=test
+      jdk: openjdk8
+
+    # Test Clojure master against a single JDK
+    - env: VERSION=master TARGET=test
+      jdk: oraclejdk9
+
+    # Coverage analysis
+    - env: VERSION=1.9 TARGET=cloverage
+      jdk: oraclejdk8
+      after_success: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
+
+    # Eastwood linter
+    - stage: check
+      env: VERSION=1.9 TARGET=eastwood
+      jdk: oraclejdk8
+
+    # Check cljfmt
+    - stage: check
+      env: VERSION=1.9 TARGET=cljfmt
+      jdk: oraclejdk8
+
+    # Deploy artifacts
+    #- stage: deploy
+    #  env: TARGET=deploy
+    #  jdk: oraclejdk8
+
+  fast_finish: true      # don't wait for allowed failures before build finish
+  allow_failures:
+    - env: VERSION=master TARGET=test
+    - env: VERSION=1.9 TARGET=cloverage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: test eastwood cljfmt cloverage release deploy clean
+
+VERSION ?= 1.9
+
+# Some tests need to be filtered based on JVM version.  This selector
+# will be mapped to a function in project.clj, and that function
+# determines which `deftest` to run based on their metadata.
+JAVA_VERSION := $(shell lein with-profile +sysutils \
+                        sysutils :java-version-simple | cut -d " " -f 2)
+
+test:
+	if [ "$(JAVA_VERSION)" = "9" ]; then \
+            lein with-profile +$(VERSION) \
+                 update-in :jvm-opts concat '["--add-modules" "java.xml.bind"]' \
+                 -- test; \
+        else \
+            lein with-profile +$(VERSION) test; \
+        fi
+
+eastwood:
+	lein with-profile +$(VERSION),+eastwood eastwood
+
+cljfmt:
+	lein with-profile +$(VERSION),+cljfmt cljfmt check
+
+cloverage:
+	lein with-profile +$(VERSION),+cloverage \
+             cloverage --codecov -e clojure.tools.reader.*
+
+# When releasing, the BUMP variable controls which field in the
+# version string will be incremented in the *next* snapshot
+# version. Typically this is either "major", "minor", or "patch".
+
+BUMP ?= patch
+
+release:
+	lein with-profile +$(VERSION) release $(BUMP)
+
+# Deploying requires the caller to set environment variables as
+# specified in project.clj to provide a login and password to the
+# artifact repository.
+
+deploy:
+	lein with-profile +$(VERSION) deploy clojars
+
+clean:
+	lein clean

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/clojure-emacs/piggieback.png?branch=master)](http://travis-ci.org/clojure-emacs/piggieback)
+[![codecov](https://codecov.io/gh/clojure-emacs/orchard/branch/master/graph/badge.svg)](https://codecov.io/gh/clojure-emacs/piggieback)
 
 # Piggieback
 

--- a/eastwood.clj
+++ b/eastwood.clj
@@ -4,14 +4,14 @@
   :within-depth 1
   :reason "The `is` macro commonly expands to contain an `if` with a condition that is a constant."})
 
-#_(disable-warning
- {:linter :constant-test
-  :if-inside-macroexpansion-of #{'debugger.core/break}
-  :within-depth 7
-  :reason "The `break` macro commonly expands to contain an `if` with a condition that is a constant."})
+(disable-warning
+ {:linter :unused-ret-vals-in-try
+  :if-inside-macroexpansion-of #{'cemerick.piggieback/with-rhino-context}
+  :within-depth 3
+  :reason "The `with-rhino-context` macro intentionally discards ` (. org.mozilla.javascript.Context enter)`"})
 
-#_(disable-warning
- {:linter :constant-test
-  :if-inside-macroexpansion-of #{'clojure.core/cond->}
-  :within-depth 2
-  :reason "The `cond->` macro can legitimately contain always-true predicates."})
+(disable-warning
+ {:linter :unused-ret-vals
+  :if-inside-macroexpansion-of #{'cemerick.piggieback-test/eastwood-ignore-unused-ret}
+  :within-depth 3
+  :reason "The macro wraps expressions that are used solely for side-effects in the repl session."})

--- a/eastwood.clj
+++ b/eastwood.clj
@@ -1,0 +1,17 @@
+(disable-warning
+ {:linter :constant-test
+  :if-inside-macroexpansion-of #{'clojure.test/is}
+  :within-depth 1
+  :reason "The `is` macro commonly expands to contain an `if` with a condition that is a constant."})
+
+#_(disable-warning
+ {:linter :constant-test
+  :if-inside-macroexpansion-of #{'debugger.core/break}
+  :within-depth 7
+  :reason "The `break` macro commonly expands to contain an `if` with a condition that is a constant."})
+
+#_(disable-warning
+ {:linter :constant-test
+  :if-inside-macroexpansion-of #{'clojure.core/cond->}
+  :within-depth 2
+  :reason "The `cond->` macro can legitimately contain always-true predicates."})

--- a/project.clj
+++ b/project.clj
@@ -25,11 +25,7 @@
 
              :cloverage {:plugins [[lein-cloverage "1.0.11-SNAPSHOT"]]}
 
-             :cljfmt {:plugins [[lein-cljfmt "0.5.7"]]
-                      :cljfmt  {:indents {as->                [[:inner 0]]
-                                          with-debug-bindings [[:inner 0]]
-                                          merge-meta          [[:inner 0]]
-                                          try-if-let          [[:block 1]]}}}
+             :cljfmt {:plugins [[lein-cljfmt "0.5.7"]]}
 
              :eastwood {:plugins  [[jonase/eastwood "0.2.5"]]
                         :eastwood {:config-files ["eastwood.clj"]}}}

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
-                 [org.clojure/tools.nrepl "0.2.10"]
-                 [org.clojure/clojurescript "1.9.946"]]
+  :dependencies [[org.clojure/tools.nrepl "0.2.10"]]
 
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
 
@@ -15,8 +13,26 @@
 
   :aliases  {"all" ["with-profile" "dev"]}
 
-                                        ; painful for users; https://github.com/technomancy/leiningen/issues/1771
-  :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.10"]]}}
+  ;; painful for users; https://github.com/technomancy/leiningen/issues/1771
+  :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.10"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
+                                  [org.clojure/clojurescript "1.9.946" :scope "provided"]]}
+             :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
+                      :dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]
+                                     [org.clojure/clojurescript "1.9.946" :scope "provided"]]}
+
+             :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
+
+             :cloverage {:plugins [[lein-cloverage "1.0.11-SNAPSHOT"]]}
+
+             :cljfmt {:plugins [[lein-cljfmt "0.5.7"]]
+                      :cljfmt  {:indents {as->                [[:inner 0]]
+                                          with-debug-bindings [[:inner 0]]
+                                          merge-meta          [[:inner 0]]
+                                          try-if-let          [[:block 1]]}}}
+
+             :eastwood {:plugins  [[jonase/eastwood "0.2.5"]]
+                        :eastwood {:config-files ["eastwood.clj"]}}}
 
   ;;maven central requirements
   :scm {:url "git@github.com:cemerick/piggieback.git"}

--- a/src/cemerick/piggieback.clj
+++ b/src/cemerick/piggieback.clj
@@ -21,14 +21,14 @@
            java.io.Writer)
   (:refer-clojure :exclude (load-file)))
 
-; this is the var that is checked by the middleware to determine whether an
-; active CLJS REPL is in flight
+;; this is the var that is checked by the middleware to determine whether an
+;; active CLJS REPL is in flight
 (def ^:private ^:dynamic *cljs-repl-env* nil)
 (def ^:private ^:dynamic *cljs-compiler-env* nil)
 (def ^:private ^:dynamic *cljs-repl-options* nil)
 (def ^:private ^:dynamic *original-clj-ns* nil)
 
-; ================ Rhino junk =================
+;; ================ Rhino junk =================
 
 (defn- rhino-repl-env?
   [repl-env]
@@ -53,43 +53,43 @@
 (defmacro ^:private with-rhino-context
   [& body]
   `(try
-    (Context/enter)
-    ~@body
-    (finally
-      ; -tear-down for rhino environments always calls Context/exit, so we need
-      ; to kill the resulting error to avoid an exception printing on :cljs/quit
-      (squelch-rhino-context-error (Context/exit)))))
+     (Context/enter)
+     ~@body
+     (finally
+       ;; -tear-down for rhino environments always calls Context/exit, so we need
+       ;; to kill the resulting error to avoid an exception printing on :cljs/quit
+       (squelch-rhino-context-error (Context/exit)))))
 
 (defn- map-stdout
   [rhino-env out]
   (ScriptableObject/putProperty
-    (:scope rhino-env)
-    "out"
-    (Context/javaToJS out (:scope rhino-env))))
+   (:scope rhino-env)
+   "out"
+   (Context/javaToJS out (:scope rhino-env))))
 
 (defn- setup-rhino-env
   [rhino-env options]
   (with-rhino-context
     (let [ret (cljs.repl/-setup rhino-env options)]
-      ; rhino/rhino-setup maps System/out to "out" and therefore the target of
-      ; cljs' *print-fn*! :-(
+      ;; rhino/rhino-setup maps System/out to "out" and therefore the target of
+      ;; cljs' *print-fn*! :-(
       (map-stdout rhino-env *out*)
-      ; rhino/repl-env calls (Context/enter) without a (Context/exit)
+      ;; rhino/repl-env calls (Context/enter) without a (Context/exit)
       (squelch-rhino-context-error (Context/exit))
       ret)))
 
-; ================ end Rhino junk =============
+;; ================ end Rhino junk =============
 
-; delegating REPL environments
-; all this to avoid setting up the "real" REPL environment every time we enter
-; cljs.repl/repl*, and to squelch -tear-down entirely
+;; delegating REPL environments
+;; all this to avoid setting up the "real" REPL environment every time we enter
+;; cljs.repl/repl*, and to squelch -tear-down entirely
 
-; we need a delegating REPL environment type for each concrete REPL environment
-; type we see, so that the various `satisfies?` calls that `cljs.repl` makes on
-; our delegating type are true to what is actually supported; in effect, this is
-; all a single-purpose implementation of ClojureScript's `specify`, just to be
-; able to override the implementations of -setup and -tear-down supplied for
-; each type of REPL environment
+;; we need a delegating REPL environment type for each concrete REPL environment
+;; type we see, so that the various `satisfies?` calls that `cljs.repl` makes on
+;; our delegating type are true to what is actually supported; in effect, this is
+;; all a single-purpose implementation of ClojureScript's `specify`, just to be
+;; able to override the implementations of -setup and -tear-down supplied for
+;; each type of REPL environment
 (def ^:private cljs-repl-protocol-impls
   {cljs.repl/IReplEnvOptions
    {:-repl-options (fn [repl-env] (cljs.repl/-repl-options (.-repl-env repl-env)))}
@@ -106,7 +106,7 @@
    {:-print-stacktrace (fn [repl-env stacktrace err build-options]
                          (cljs.repl/-print-stacktrace (.-repl-env repl-env) stacktrace err build-options))}})
 
-; type -> ctor-fn
+;; type -> ctor-fn
 (def ^:private repl-env-ctors (atom {}))
 
 (defn- generate-delegating-repl-env [repl-env]
@@ -114,32 +114,32 @@
         classname (.replace (.getName repl-env-class) \. \_)
         dclassname (str "Delegating" classname)]
     (eval
-      (list* 'deftype (symbol dclassname)
-        '([repl-env ^:volatile-mutable setup-return-val]
-           cljs.repl/IJavaScriptEnv
-           (-setup [this options]
-             (when (nil? setup-return-val)
-               (set! setup-return-val (atom (if (#'cemerick.piggieback/rhino-repl-env? repl-env)
-                                              (#'cemerick.piggieback/setup-rhino-env repl-env options)
-                                              (cljs.repl/-setup repl-env options)))))
-             @setup-return-val)
-           (-evaluate [this a b c] (cljs.repl/-evaluate repl-env a b c))
-           (-load [this ns url] (cljs.repl/-load repl-env ns url))
-           (-tear-down [_])
-           clojure.lang.ILookup
-           (valAt [_ k] (get repl-env k))
-           (valAt [_ k default] (get repl-env k default))
-           clojure.lang.Seqable
-           (seq [_] (seq repl-env))
-           clojure.lang.Associative
-           (containsKey [_ k] (contains? repl-env k))
-           (entryAt [_ k] (find repl-env k))
-           (assoc [_ k v] (#'cemerick.piggieback/delegating-repl-env (assoc repl-env k v) setup-return-val))
-           clojure.lang.IPersistentCollection
-           (count [_] (count repl-env))
-           (cons [_ entry] (conj repl-env entry))
-           ; pretty meaningless; most REPL envs are records for the assoc'ing, but they're not values
-           (equiv [_ other] false))))
+     (list* 'deftype (symbol dclassname)
+            '([repl-env ^:volatile-mutable setup-return-val]
+              cljs.repl/IJavaScriptEnv
+              (-setup [this options]
+                      (when (nil? setup-return-val)
+                        (set! setup-return-val (atom (if (#'cemerick.piggieback/rhino-repl-env? repl-env)
+                                                       (#'cemerick.piggieback/setup-rhino-env repl-env options)
+                                                       (cljs.repl/-setup repl-env options)))))
+                      @setup-return-val)
+              (-evaluate [this a b c] (cljs.repl/-evaluate repl-env a b c))
+              (-load [this ns url] (cljs.repl/-load repl-env ns url))
+              (-tear-down [_])
+              clojure.lang.ILookup
+              (valAt [_ k] (get repl-env k))
+              (valAt [_ k default] (get repl-env k default))
+              clojure.lang.Seqable
+              (seq [_] (seq repl-env))
+              clojure.lang.Associative
+              (containsKey [_ k] (contains? repl-env k))
+              (entryAt [_ k] (find repl-env k))
+              (assoc [_ k v] (#'cemerick.piggieback/delegating-repl-env (assoc repl-env k v) setup-return-val))
+              clojure.lang.IPersistentCollection
+              (count [_] (count repl-env))
+              (cons [_ entry] (conj repl-env entry))
+              ;; pretty meaningless; most REPL envs are records for the assoc'ing, but they're not values
+              (equiv [_ other] false))))
     (let [dclass (resolve (symbol dclassname))
           ctor (resolve (symbol (str "->" dclassname)))]
       (doseq [[protocol fn-map] cljs-repl-protocol-impls]
@@ -180,61 +180,61 @@
               *err* (@session #'*err*)
               ana/*cljs-ns* initns]
       (repl repl-env
-        (merge
-          {:need-prompt (constantly false)
-           :init (fn [])
-           :prompt (fn [])
-           :bind-err false
-           :quit-prompt (fn [])
-           :compiler-env compiler-env
-           :flush flush
-           :print (fn [result & rest]
-                    ; make sure that all *printed* output is flushed before sending results of evaluation
-                    (flush)
-                    (when (or (not ns)
-                            (not= initns ana/*cljs-ns*))
-                      (swap! session assoc #'ana/*cljs-ns* ana/*cljs-ns*))
-                    (if (::first-cljs-repl nrepl-msg)
-                      ; the first run through the cljs REPL is effectively part
-                      ; of setup; loading core, (ns cljs.user ...), etc, should
-                      ; not yield a value. But, we do capture the compiler
-                      ; environment now (instead of attempting to create one to
-                      ; begin with, because we can't reliably replicate what
-                      ; cljs.repl/repl* does in terms of options munging
-                      (set! *cljs-compiler-env* env/*compiler*)
-                      ; if the CLJS evaluated result is nil, then we can assume
-                      ; what was evaluated was a cljs.repl special fn (e.g. in-ns,
-                      ; require, etc)
-                      (transport/send transport (response-for nrepl-msg
-                                                  {:value (or result "nil")
-                                                   :printed-value 1
-                                                   :ns (@session #'ana/*cljs-ns*)}))))
-           :caught (partial repl-caught session transport nrepl-msg)}
-          options)))))
+            (merge
+             {:need-prompt (constantly false)
+              :init (fn [])
+              :prompt (fn [])
+              :bind-err false
+              :quit-prompt (fn [])
+              :compiler-env compiler-env
+              :flush flush
+              :print (fn [result & rest]
+                       ;; make sure that all *printed* output is flushed before sending results of evaluation
+                       (flush)
+                       (when (or (not ns)
+                                 (not= initns ana/*cljs-ns*))
+                         (swap! session assoc #'ana/*cljs-ns* ana/*cljs-ns*))
+                       (if (::first-cljs-repl nrepl-msg)
+                         ;; the first run through the cljs REPL is effectively part
+                         ;; of setup; loading core, (ns cljs.user ...), etc, should
+                         ;; not yield a value. But, we do capture the compiler
+                         ;; environment now (instead of attempting to create one to
+                         ;; begin with, because we can't reliably replicate what
+                         ;; cljs.repl/repl* does in terms of options munging
+                         (set! *cljs-compiler-env* env/*compiler*)
+                         ;; if the CLJS evaluated result is nil, then we can assume
+                         ;; what was evaluated was a cljs.repl special fn (e.g. in-ns,
+                         ;; require, etc)
+                         (transport/send transport (response-for nrepl-msg
+                                                                 {:value (or result "nil")
+                                                                  :printed-value 1
+                                                                  :ns (@session #'ana/*cljs-ns*)}))))
+              :caught (partial repl-caught session transport nrepl-msg)}
+             options)))))
 
-; This function always executes when the nREPL session is evaluating Clojure,
-; via interruptible-eval, etc. This means our dynamic environment is in place,
-; so set! and simple dereferencing is available. Contrast w/ evaluate and
-; load-file below.
+;; This function always executes when the nREPL session is evaluating Clojure,
+;; via interruptible-eval, etc. This means our dynamic environment is in place,
+;; so set! and simple dereferencing is available. Contrast w/ evaluate and
+;; load-file below.
 (defn cljs-repl
   "Starts a ClojureScript REPL over top an nREPL session.  Accepts
    all options usually accepted by e.g. cljs.repl/repl."
   [repl-env & {:as options}]
-  ; TODO I think we need a var to set! the compiler environment from the REPL
-  ; environment after each eval
+  ;; TODO I think we need a var to set! the compiler environment from the REPL
+  ;; environment after each eval
   (try
     (let [repl-env (delegating-repl-env repl-env nil)]
       (set! ana/*cljs-ns* 'cljs.user)
-      ; this will implicitly set! *cljs-compiler-env*
+      ;; this will implicitly set! *cljs-compiler-env*
       (run-cljs-repl (assoc ieval/*msg* ::first-cljs-repl true)
-        (nrepl/code (ns cljs.user
-                      (:require [cljs.repl :refer-macros (source doc find-doc
-                                                           apropos dir pst)])))
-        repl-env nil options)
-      ; (clojure.pprint/pprint (:options @*cljs-compiler-env*))
+                     (nrepl/code (ns cljs.user
+                                   (:require [cljs.repl :refer-macros (source doc find-doc
+                                                                              apropos dir pst)])))
+                     repl-env nil options)
+      ;; (clojure.pprint/pprint (:options @*cljs-compiler-env*))
       (set! *cljs-repl-env* repl-env)
       (set! *cljs-repl-options* options)
-      ; interruptible-eval is in charge of emitting the final :ns response in this context
+      ;; interruptible-eval is in charge of emitting the final :ns response in this context
       (set! *original-clj-ns* *ns*)
       (set! *ns* (find-ns ana/*cljs-ns*))
       (println "To quit, type:" :cljs/quit))
@@ -245,14 +245,14 @@
 ;; mostly a copy/paste from interruptible-eval
 (defn- enqueue [{:keys [session transport] :as msg} func]
   (ieval/queue-eval session @ieval/default-executor
-    (fn []
-      (alter-meta! session assoc
-        :thread (Thread/currentThread)
-        :eval-msg msg)
-      (binding [ieval/*msg* msg]
-        (func)
-        (transport/send transport (response-for msg :status :done))
-        (alter-meta! session dissoc :thread :eval-msg)))))
+                    (fn []
+                      (alter-meta! session assoc
+                                   :thread (Thread/currentThread)
+                                   :eval-msg msg)
+                      (binding [ieval/*msg* msg]
+                        (func)
+                        (transport/send transport (response-for msg :status :done))
+                        (alter-meta! session dissoc :thread :eval-msg)))))
 
 (defn read-cljs-string [form-str]
   (when-not (string/blank? form-str)
@@ -311,10 +311,10 @@
         (catch Throwable t
           (repl-caught session transport msg t repl-env repl-options))))))
 
-; only executed within the context of an nREPL session having *cljs-repl-env*
-; bound. Thus, we're not going through interruptible-eval, and the user's
-; Clojure session (dynamic environment) is not in place, so we need to go
-; through the `session` atom to access/update its vars. Same goes for load-file.
+;; only executed within the context of an nREPL session having *cljs-repl-env*
+;; bound. Thus, we're not going through interruptible-eval, and the user's
+;; Clojure session (dynamic environment) is not in place, so we need to go
+;; through the `session` atom to access/update its vars. Same goes for load-file.
 (defn- evaluate [{:keys [session transport ^String code] :as msg}]
   (if-not (.. code trim (endsWith ":cljs/quit"))
     (do-eval msg)
@@ -323,34 +323,34 @@
         (with-rhino-context (cljs.repl/-tear-down actual-repl-env))
         (cljs.repl/-tear-down actual-repl-env))
       (swap! session assoc
-        #'*ns* (@session #'*original-clj-ns*)
-        #'*cljs-repl-env* nil
-        #'*cljs-compiler-env* nil
-        #'*cljs-repl-options* nil
-        #'ana/*cljs-ns* 'cljs.user)
+             #'*ns* (@session #'*original-clj-ns*)
+             #'*cljs-repl-env* nil
+             #'*cljs-compiler-env* nil
+             #'*cljs-repl-options* nil
+             #'ana/*cljs-ns* 'cljs.user)
       (transport/send transport (response-for msg
-                                  :value "nil"
-                                  :printed-value 1
-                                  :ns (str (@session #'*original-clj-ns*)))))))
+                                              :value "nil"
+                                              :printed-value 1
+                                              :ns (str (@session #'*original-clj-ns*)))))))
 
-; struggled for too long trying to interface directly with cljs.repl/load-file,
-; so just mocking a "regular" load-file call
-; this seems to work perfectly, *but* it only loads the content of the file from
-; disk, not the content of the file sent in the message (in contrast to nREPL on
-; Clojure). This is necessitated by the expectation of cljs.repl/load-file that
-; the file being loaded is on disk, in the location implied by the namespace
-; declaration.
-; TODO either pull in our own `load-file` that doesn't imply this, or raise the issue upstream.
+;; struggled for too long trying to interface directly with cljs.repl/load-file,
+;; so just mocking a "regular" load-file call
+;; this seems to work perfectly, *but* it only loads the content of the file from
+;; disk, not the content of the file sent in the message (in contrast to nREPL on
+;; Clojure). This is necessitated by the expectation of cljs.repl/load-file that
+;; the file being loaded is on disk, in the location implied by the namespace
+;; declaration.
+;; TODO either pull in our own `load-file` that doesn't imply this, or raise the issue upstream.
 (defn- load-file [{:keys [session transport file-path] :as msg}]
   (evaluate (assoc msg :code (format "(load-file %s)" (pr-str file-path)))))
 
 (defn wrap-cljs-repl [handler]
   (fn [{:keys [session op] :as msg}]
     (let [handler (or (when-let [f (and (@session #'*cljs-repl-env*)
-                                     ({"eval" #'evaluate "load-file" #'load-file} op))]
+                                        ({"eval" #'evaluate "load-file" #'load-file} op))]
                         (fn [msg] (enqueue msg #(f msg))))
-                    handler)]
-      ; ensure that bindings exist so cljs-repl can set!
+                      handler)]
+      ;; ensure that bindings exist so cljs-repl can set!
       (when-not (contains? @session #'*cljs-repl-env*)
         (swap! session (partial merge {#'*cljs-repl-env* *cljs-repl-env*
                                        #'*cljs-compiler-env* *cljs-compiler-env*
@@ -360,7 +360,7 @@
       (handler msg))))
 
 (set-descriptor! #'wrap-cljs-repl
-  {:requires #{"clone"}
-   ; piggieback unconditionally hijacks eval and load-file
-   :expects #{"eval" "load-file"}
-   :handles {}})
+                 {:requires #{"clone"}
+                  ;; piggieback unconditionally hijacks eval and load-file
+                  :expects #{"eval" "load-file"}
+                  :handles {}})

--- a/test/cemerick/piggieback_test.clj
+++ b/test/cemerick/piggieback_test.clj
@@ -11,8 +11,8 @@
   (assert (= ["user"]
              (filter identity
                      (map :ns (nrepl/message
-                                session
-                                {:op "eval" :code "clojure.core/*ns*"}))))))
+                               session
+                               {:op "eval" :code "clojure.core/*ns*"}))))))
 
 (def ^:private jdk8+ (try (import 'java.time.Instant)
                           true
@@ -22,11 +22,11 @@
   (if jdk8+
     (do (require 'cljs.repl.nashorn)
         (nrepl/code
-          (cemerick.piggieback/cljs-repl
-            (cljs.repl.nashorn/repl-env))))
+         (cemerick.piggieback/cljs-repl
+          (cljs.repl.nashorn/repl-env))))
     (nrepl/code
-      (cemerick.piggieback/cljs-repl
-        (cljs.repl.rhino/repl-env)))))
+     (cemerick.piggieback/cljs-repl
+      (cljs.repl.rhino/repl-env)))))
 
 (defn repl-server-fixture
   [f]
@@ -36,13 +36,13 @@
     (let [port (.getLocalPort (:ss @server))
           conn (nrepl/connect :port port)
           session (nrepl/client-session (nrepl/client conn Long/MAX_VALUE))]
-      ; need to let the dynamic bindings get in place before trying to eval anything that
-      ; depends upon those bingings being set
+      ;; need to let the dynamic bindings get in place before trying to eval anything that
+      ;; depends upon those bingings being set
       (doall (nrepl/message session {:op "eval" :code cljs-repl-start-code}))
       (try
         (binding [*server-port* port
                   *session* session]
-        (f))
+          (f))
         (finally
           (doall (nrepl/message session {:op "eval" :code ":cljs/quit"}))
           (assert-exit-ns session "user"))))))
@@ -50,45 +50,45 @@
 (use-fixtures :once repl-server-fixture)
 
 (deftest default-sanity
-  ; I think there's a race condition between when previous expressions are evaluated
-  ; (which nREPL serializes for a session) and when the next code to be evaluated is analyzed
-  ; in piggieback (which has no visibility into the session serialization mechanism). The
-  ; fix is to work like a REPL _should_, i.e. wait for the full response of an evaluation
-  ; prior to sending out another chunk of code.
+  ;; I think there's a race condition between when previous expressions are evaluated
+  ;; (which nREPL serializes for a session) and when the next code to be evaluated is analyzed
+  ;; in piggieback (which has no visibility into the session serialization mechanism). The
+  ;; fix is to work like a REPL _should_, i.e. wait for the full response of an evaluation
+  ;; prior to sending out another chunk of code.
   (doall (nrepl/message *session* {:op "eval" :code "(defn x [] (into [] (js/Array 1 2 3)))"}))
   (is (= [1 2 3] (->> {:op "eval" :code "(x)"} (nrepl/message *session*) nrepl/response-values first))))
 
 (deftest printing-works
   (is (= {:value ["nil"] :out "[1 2 3 4]\n"}
-        (-> (nrepl/message *session* {:op "eval" :code "(println [1 2 3 4])"})
-          nrepl/combine-responses
-          (select-keys [:value :out])))))
+         (-> (nrepl/message *session* {:op "eval" :code "(println [1 2 3 4])"})
+             nrepl/combine-responses
+             (select-keys [:value :out])))))
 
 (deftest proper-ns-tracking
   (is (= "cljs.user" (-> (nrepl/message *session* {:op "eval" :code "5"})
-                       nrepl/combine-responses
-                       :ns)))
+                         nrepl/combine-responses
+                         :ns)))
   (is (= "foo.bar" (-> (nrepl/message *session* {:op "eval" :code "(ns foo.bar)"})
                        nrepl/combine-responses
                        :ns)))
   (doall (nrepl/message *session* {:op "eval" :code "(defn ns-tracking [] (into [] (js/Array 1 2 3)))"}))
-  
+
   (is (= ["[1 2 3]"] (-> (nrepl/message *session* {:op "eval" :code "(ns-tracking)"})
-                       nrepl/combine-responses
-                       :value)))
-  
+                         nrepl/combine-responses
+                         :value)))
+
   ;; TODO emit a response message to in-ns, doesn't seem to hit eval....
   (is (= "cljs.user" (-> (nrepl/message *session* {:op "eval" :code "(in-ns 'cljs.user)"})
-                       nrepl/combine-responses
-                       :ns)))
+                         nrepl/combine-responses
+                         :ns)))
   (is (= "cljs.user" (-> (nrepl/message *session* {:op "eval" :code "(ns cljs.user)"})
-                       nrepl/combine-responses
-                       :ns)))
+                         nrepl/combine-responses
+                         :ns)))
   (let [resp (-> (nrepl/message *session* {:op "eval" :code "(ns-tracking)" :ns "foo.bar"})
-               nrepl/combine-responses)]
+                 nrepl/combine-responses)]
     (is (= ["[1 2 3]"] (:value resp)))
     (is (= "cljs.user" (:ns resp))))
-  
+
   (is (= "foo.bar" (-> (nrepl/message *session* {:op "eval" :code "(ns foo.bar)" :ns "cljs.user"})
-                     nrepl/combine-responses
-                     :ns))))
+                       nrepl/combine-responses
+                       :ns))))

--- a/test/cemerick/piggieback_test.clj
+++ b/test/cemerick/piggieback_test.clj
@@ -31,7 +31,8 @@
 (defn repl-server-fixture
   [f]
   (with-open [server (server/start-server
-                       :handler (server/default-handler #'cemerick.piggieback/wrap-cljs-repl))]
+                      :bind "localhost"
+                      :handler (server/default-handler #'cemerick.piggieback/wrap-cljs-repl))]
     (let [port (.getLocalPort (:ss @server))
           conn (nrepl/connect :port port)
           session (nrepl/client-session (nrepl/client conn Long/MAX_VALUE))]


### PR DESCRIPTION

This PR adds:
- Code quality checks via Cloverage, Eastwood, and Cljfmt (with fixes necessary to make them pass)
- Build and test with Clojure 1.10.0-master-SNAPSHOT, as well as 1.9
- Tests with OracleJDK 9
- Makefile with targets to take care of the above

and removes:
- Building w/ Clojure 1.8
- Tests with OpenJDK 7 and OracleJDK 7

Two specific things I'm requesting additional eyes on:
(1) [this macro](https://github.com/clojure-emacs/piggieback/compare/master...gonewest818:travis-update?expand=1#diff-4b0a13d891f2a487f4809cc885c2ce51R31) which is really nothing more than a dummy to tell Eastwood I don't care about the return values in the body.  Is there a more elegant way to deal with this?
(2) `project.clj`.  Because I'm testing on multiple Clojure releases I don't want/need to declare clojure and clojurescript as `:dependencies`, they need to be specified in profiles. But I'm not sure I've got that set up correctly.
